### PR TITLE
Fix use of deprecated array and string offset access syntax

### DIFF
--- a/src/DataObjects/QueuedJobDescriptor.php
+++ b/src/DataObjects/QueuedJobDescriptor.php
@@ -209,7 +209,7 @@ class QueuedJobDescriptor extends DataObject
     {
         // make sure our temp dir is in place. This is what will be inotify watched
         $jobDir = Config::inst()->get(QueuedJobService::class, 'cache_dir');
-        if ($jobDir{0} != '/') {
+        if ($jobDir[0] != '/') {
             $jobDir = TEMP_FOLDER . '/' . $jobDir;
         }
 


### PR DESCRIPTION
# Fix use of deprecated array and string offset access syntax

Fixes the PHP warning:
```
PHP Deprecated:  Array and string offset access syntax with curly braces is deprecated in /var/www/mysite/www/vendor/symbiote/silverstripe-queuedjobs/src/DataObjects/QueuedJobDescriptor.php on line 212
```